### PR TITLE
Automatic update of joints locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The plugin as it exists here is free for all uses.  However, there are certain f
 - Randomize/reset body shape<sup>1, 2</sup> 
 - Randomize/reset face shape<sup>1, 2</sup> 
 - Randomize/reset facial expression <sup>1, 2</sup> 
-- Update joint locations<sup>1, 2</sup> 
 - Position feet on ground plane
 - Enable/disable corrective poseshapes for a single frame or for multiple frames
 - Change hand pose (flat, relaxed)<sup>2</sup> 
@@ -105,7 +104,7 @@ SMPLX and SUPR bodies have facial expression support.  The plugin comes with 6 p
 
 ## Modifying Shape and Loading Poses
 
-If you have the additional data folder, you have access to a few more features of the plugin.  The first is modifying the body shape.  There are sliders to change the avatar’s height and weight, along with `Random Body Shape` and `Random Face Shape` buttons.  The joint locations are automatically updated if you use any of the body shape modification tools from the plugin.  You can also fine tune the shape of your avatar using the `Shape` blend shapes in the Object Data Properties panel.  If you do that, you need to manually click the `Update Joint Locations` button to calculate the new joint locations.
+If you have the additional data folder, you have access to a few more features of the plugin.  The first is modifying the body shape.  There are sliders to change the avatar’s height and weight, along with `Random Body Shape` and `Random Face Shape` buttons.  The joint locations are automatically updated if you use any of the body shape modification tools from the plugin.  You can also fine tune the shape of your avatar using the `Shape` blend shapes in the Object Data Properties panel. 
 
 Along with this, you can also load in poses onto your avatars if you have .npz files that contain animation data (like [AMASS](https://amass.is.tue.mpg.de/), which is free for non-commercial scientific research).  If you are loading a pose, be sure to select the correct up-axis in the import options in the top right corner of the popup dialogue.
 

--- a/meshcapade_addon/meshcapade_addon.py
+++ b/meshcapade_addon/meshcapade_addon.py
@@ -6,6 +6,11 @@ from . import (
 )
 
 
+handle_shape_key_change=object()
+def shape_key_change(*args):
+    bpy.ops.object.update_joint_locations('EXEC_DEFAULT')
+
+
 def register():
     for prop_class in properties.PROPERTY_CLASSES:
         bpy.utils.register_class(prop_class)
@@ -19,6 +24,16 @@ def register():
     properties.define_props()
 
 
+    #subscribe to changes of the shape keys and call the function to update the joint locations
+    bpy.msgbus.subscribe_rna(
+        key =  bpy.types.ShapeKey, #will check for all the properties changes in ShapeKeys. We are mostly interested in .value and .mute
+        owner=handle_shape_key_change,
+        args=(1, 2, 3),
+        notify=shape_key_change
+    )
+
+
+
 def unregister():
     properties.destroy_props()
 
@@ -30,3 +45,6 @@ def unregister():
 
     for prop_class in reversed(properties.PROPERTY_CLASSES):
         bpy.utils.unregister_class(prop_class)
+
+    bpy.msgbus.clear_by_owner(handle_shape_key_change)
+

--- a/meshcapade_addon/operators.py
+++ b/meshcapade_addon/operators.py
@@ -866,7 +866,10 @@ class OP_UpdateJointLocations(bpy.types.Operator):
         betas = []
         for key_block in obj.data.shape_keys.key_blocks:
             if key_block.name.startswith("Shape"):
-                betas.append(key_block.value)
+                if not key_block.mute:
+                    betas.append(key_block.value)
+                else: #if the value is unchecked in the gui, it's regarded as zero
+                    betas.append(0.0)
         num_betas = len(betas)
         betas = np.array(betas)
 

--- a/meshcapade_addon/ui.py
+++ b/meshcapade_addon/ui.py
@@ -83,7 +83,6 @@ class SMPL_PT_Shape(bpy.types.Panel):
         split3.prop(context.window_manager.smpl_tool, "random_face_mult")
 
         col2.separator()
-        col2.operator("object.update_joint_locations")
 
 
 class SMPL_PT_Pose(bpy.types.Panel):


### PR DESCRIPTION
Previously changing the shape keys through the object data tab did not trigger a update of joint locations. The user needed to manually click on the "Update joint locations" button. 

This implements a listener for changes in the shape key and automatically triggers the update of the joints. Therefore the button is now removed from the gui. 

Also fixed a small oversight in which disabling a shape key did not properly set it to zero. 