### PR TITLE
FIX: Missing fps incorrectly handled

### DIFF
--- a/meshcapade_addon/operators.py
+++ b/meshcapade_addon/operators.py
@@ -124,10 +124,10 @@ class OP_LoadAvatar(bpy.types.Operator, ImportHelper):
             elif "fps" in data:
                 fps_key = "fps"
 
-            if not fps_key:
-                error_string += "\n -fps or mocap_framerate or mocap_frame_rate"
-            else: 
+            try:
                 fps = int(data[fps_key])
+            except NameError:
+                error_string += "\n -fps or mocap_framerate or mocap_frame_rate"               
 
             if "betas" not in data:
                 error_string += "\n -betas"


### PR DESCRIPTION
If 'fps' is missing form the NPZ file, the addon throws a silent NameError instead of correctly outputting an error message.